### PR TITLE
staging

### DIFF
--- a/src/components/files/views/grid/ImagePreviewGrid.tsx
+++ b/src/components/files/views/grid/ImagePreviewGrid.tsx
@@ -53,7 +53,7 @@ export const ImagePreviewGrid = ({ file, selected, onClick, onSelect, className 
             <ContextMenu key={file.id} modal={false}>
                 <ContextMenuTrigger asChild>
                     <button ref={setNodeRef} onClick={onClick} className="unset cursor-pointer" style={style} {...listeners} {...attributes}>
-                        <div className={cn(`inline-block w-40 sm:w-64 rounded-2xl ${selected.includes(file.id) ? "bg-accent" : ""}`, className)}>
+                        <div className={cn(`inline-block w-full sm:w-64 rounded-2xl ${selected.includes(file.id) ? "bg-accent" : ""}`, className)}>
                             <div className={`${selected.includes(file.id) ? "scale-95" : ""}`}>
                                 <div className={`relative h-32 sm:h-36 mb-4 flex justify-center items-center group`}>
                                     {file.type === FileType.VIDEO

--- a/src/components/files/views/grid/ImagesGrid.tsx
+++ b/src/components/files/views/grid/ImagesGrid.tsx
@@ -353,7 +353,7 @@ export const ImagesGrid = ({ sortState }: { sortState: ImagesSortMethod }) => {
                 : null
             }
             <div className={cn(
-                files.length === 0 ? "flex flex-col lg:flex-row justify-center" : "grid grid-cols-[repeat(auto-fill,10rem)] sm:grid-cols-[repeat(auto-fill,16rem)] gap-3 sm:gap-3 mx-auto",
+                files.length === 0 ? "flex flex-col lg:flex-row justify-center" : "grid grid-cols-[repeat(auto-fill,minmax(10rem,1fr))] sm:grid-cols-[repeat(auto-fill,16rem)] justify-items-start gap-3 sm:gap-3 mx-auto",
                 "relative overflow-hidden"
             )}>
                 {folder.description


### PR DESCRIPTION
- **Sidebar link and page**
- **Padded layout. Map integration**
- **Sizing the map correctly**
- **Exemple use of markers**
- **Dashboard in padded-layout**
- **Exif in DB, markers based on existing gps**
- **Custom cluster markers**
- **Custom cluster**
- **Rounded corners**
- **Custom cluster icon**
- **Folder list. POI marker**
- **POI market, signedurl feeded server side**
- **Remove sample data**
- **Adjust radius**
- **Ripple effect on folders cards**
- **Displayed markers stick to selected folders**
- **Count files on folder cards**
- **File carousel**
- **Auto map on file change**
- **Carousel enter/exit animation**
- **Fix unique folders**
- **Naming**
- **Dep**
- **Review share dialog**
- **Link to map in folder content if allowed**
- **Folder list empty display files fix**
- **Allow map token persist to db**
- **Fix default selected folders**
- **Center carousel correctly so its responsive**
- **Use of file context**
- **Read signedup url duration 24 hours**
- **Cluster widget**
- **Fix display name**
- **Add bucket env var in action**
- **Added others env vars**
- **Run only on opened and push on pr targeting staging and main**
- **Fix external storage img**
- **Fix exif types**
- **Is map allowed in links table**
- **Change map access from dropdown**
- **Fix cover share params**
- **Folders list in dropdown on mobile**
- **Change breakpoint, hide dropdown on large devices**
- **Upgrade to next 15**
- **Move server component external package**
- **Fix migration errors. Upgrade calendar to support newer react-day-picker version**
- **feat(grid): responsive image grid fill space**
